### PR TITLE
fix: set grouping to false in stake amount

### DIFF
--- a/web/src/pages/StakingRound/utils/stakingRound.ts
+++ b/web/src/pages/StakingRound/utils/stakingRound.ts
@@ -35,7 +35,7 @@ export const getLockDataParallelToApplicationIds = (
       amount: parseUnits(
         (applicationsToStakeAmount[project.id] || 0).toLocaleString("en-US", {
           maximumFractionDigits: 18,
-          useGrouping: true,
+          useGrouping: false,
         }),
         18,
       ),


### PR DESCRIPTION
this was making parseUnit to fail, not allowing users to stake any amount greater than 999